### PR TITLE
Fix for Vivaldi showing zero innerWidth on first load

### DIFF
--- a/newtab.js
+++ b/newtab.js
@@ -1932,8 +1932,10 @@ document.addEventListener('keydown', function(event) {
 });
 
 // fix scrollbar jump
+// fix for Vivaldi showing zero innerWidth on first load
 window.onresize = function(event) {
-	document.body.style.width = window.innerWidth + 'px';
+  const windowWidth = window.innerWidth;
+	document.body.style.width = windowWidth == 0 ? '100%' : windowWidth + 'px';
 	updateTooltips();
 };
 window.onresize();


### PR DESCRIPTION
It looks like Vivaldi is incorrectly returning a `window.innerWidth` of `0` on the first load as pointed out in #106.

I am not too sure what the original "scrollbar jump fix" does, but I added in a check to set the width to `100%` if a value of `0` is found.

Hopefully Vivaldi fixes this bug, but this seems like a good workaround for now.